### PR TITLE
Render agent response as markdown using react-markdown

### DIFF
--- a/components/ResultsDisplay.tsx
+++ b/components/ResultsDisplay.tsx
@@ -1,5 +1,6 @@
 import { Sparkles } from "lucide-react";
 import { ThinkingLogs } from "./ThinkingLogs";
+import Markdown from 'react-markdown';
 
 interface ResultsDisplayProps {
   result: string;
@@ -42,9 +43,9 @@ export function ResultsDisplay({ result, thinkingLogs }: ResultsDisplayProps) {
       </div>
       <div className="px-8 pb-8">
         <div className="bg-gray-50 rounded-lg p-6 border border-gray-200">
-          <pre className="whitespace-pre-wrap text-sm leading-relaxed font-mono overflow-x-auto text-gray-800">
-            {renderTextWithLinks(result)}
-          </pre>
+          <div className="prose max-w-none text-sm leading-relaxed overflow-x-auto text-gray-800 markdown-body" style={{fontFamily: 'inherit'}}>
+            <Markdown>{result}</Markdown>
+          </div>
         </div>
 
         <ThinkingLogs

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "typescript": "^5.8.3"
   },
   "dependencies": {
+    "react-markdown": "^9.0.0",
     "@vercel/sandbox": "^0.0.10",
     "ai": "5.0.0-beta.1",
     "botid": "^1.5.5",


### PR DESCRIPTION
- Adds `react-markdown` to dependencies.
- Updates `ResultsDisplay` to render agent response as markdown using `<Markdown>` instead of a plain `<pre>`. 
- Usage of `pnpm install` is required after this PR to update lockfile and install `react-markdown`.